### PR TITLE
Add note sync via SQLite

### DIFF
--- a/app/api/notes/route.ts
+++ b/app/api/notes/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifySession } from '@/lib/auth'
+import { getNote, upsertNote, initDB } from '@/lib/db'
+
+export async function GET(request: NextRequest) {
+  const sessionToken = request.cookies.get('session')?.value
+  const session = verifySession(sessionToken)
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const date = request.nextUrl.searchParams.get('date')
+  if (!date) return NextResponse.json({ error: 'Missing date' }, { status: 400 })
+  initDB()
+  const note = getNote(session.userId, date)
+  return NextResponse.json({ note })
+}
+
+export async function POST(request: NextRequest) {
+  const sessionToken = request.cookies.get('session')?.value
+  const session = verifySession(sessionToken)
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const { date, content } = await request.json()
+  if (!date) return NextResponse.json({ error: 'Missing date' }, { status: 400 })
+  initDB()
+  upsertNote(session.userId, date, content || '')
+  return NextResponse.json({ success: true })
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,12 +1,14 @@
 import { execFileSync } from 'child_process'
 import { join } from 'path'
-import fs from 'fs'
-
 const dbPath = join(process.cwd(), 'database.sqlite')
 
 export function initDB() {
-  if (!fs.existsSync(dbPath)) {
-    execFileSync('sqlite3', [dbPath, 'CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT);'])
+  const commands = [
+    "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT);",
+    "CREATE TABLE IF NOT EXISTS notes (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, date TEXT, content TEXT, last_modified INTEGER, UNIQUE(user_id, date));",
+  ]
+  for (const cmd of commands) {
+    execFileSync('sqlite3', [dbPath, cmd])
   }
 }
 
@@ -32,4 +34,18 @@ export function getUser(username: string) {
 export function createUser(username: string, password: string) {
   initDB()
   run(`INSERT INTO users (username, password) VALUES ('${escape(username)}','${escape(password)}');`)
+}
+
+export function getNote(userId: number, date: string) {
+  initDB()
+  const rows = query(`SELECT content, last_modified FROM notes WHERE user_id = ${userId} AND date = '${escape(date)}' LIMIT 1;`)
+  if (rows[0]) {
+    return { content: rows[0].content as string, lastModified: Number(rows[0].last_modified) * 1000 }
+  }
+  return undefined
+}
+
+export function upsertNote(userId: number, date: string, content: string) {
+  initDB()
+  run(`INSERT INTO notes (user_id, date, content, last_modified) VALUES (${userId}, '${escape(date)}', '${escape(content)}', strftime('%s','now')) ON CONFLICT(user_id, date) DO UPDATE SET content='${escape(content)}', last_modified=strftime('%s','now');`)
 }


### PR DESCRIPTION
## Summary
- create `notes` table and support functions
- implement API endpoint for note management
- add client-side fetch/save to journal

## Testing
- `npm run lint` *(fails: prompts for eslint configuration)*
- `npm run build` *(fails: unable to fetch fonts without internet)*

------
https://chatgpt.com/codex/tasks/task_e_688a0d1fe624832fa7daedd3fed37f9d