### PR TITLE
Fix saving indicator

### DIFF
--- a/app/JournalApp.tsx
+++ b/app/JournalApp.tsx
@@ -103,7 +103,9 @@ export default function JournalApp() {
     return () => {
       if (saveTimeoutRef.current) {
         clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = null;
       }
+      setIsSaving(false);
     };
   }, [currentContent, dateKey, selectedDate]);
 
@@ -220,7 +222,7 @@ export default function JournalApp() {
                       variant="ghost"
                       className={cn(
                         'h-9 px-4 rounded-lg hover:bg-gray-100/80 font-medium text-[13px]',
-                        isToday(selectedDate) ? 'text-blue-600' : 'text-gray-700'
+                        isToday(selectedDate) ? 'text-black' : 'text-gray-700'
                       )}
                     >
                       {isToday(selectedDate) ? 'Today' : format(selectedDate, 'MMM d, yyyy')}


### PR DESCRIPTION
## Summary
- fix stuck "Saving..." state on note changes
- show "Today" date in black instead of blue

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build` *(fails due to failing to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_688b25d04204832fbedc46e006565393