### PR TITLE
Track each journal line separately

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -8,8 +8,9 @@ This project is a Next.js application that allows employees to log order status 
 - **SQLite** is used as the persistence layer (`database.sqlite`).
 - Tables:
   - `users` – stores user credentials (`id`, `username`, `password`).
-  - `notes` – stores order notes (`user_id`, `date`, `content`, `last_modified`).
-- Database helpers in `lib/db.ts` provide CRUD operations. A new `getAllNotes` function aggregates every note with its author.
+  - `notes` – legacy table storing full documents for a day.
+  - `note_lines` – stores each line of a note separately (`user_id`, `date`, `line_index`, `content`, `last_modified`).
+- Database helpers in `lib/db.ts` provide CRUD operations. `getAllNotes` aggregates notes across users for the AI assistant.
 
 ### Authentication
 - Sessions are signed tokens stored in a cookie. Creation and verification logic lives in `lib/auth.ts`.

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5,7 +5,10 @@ const dbPath = join(process.cwd(), 'database.sqlite')
 export function initDB() {
   const commands = [
     "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT);",
+    // legacy table kept for compatibility but no longer used
     "CREATE TABLE IF NOT EXISTS notes (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, date TEXT, content TEXT, last_modified INTEGER, UNIQUE(user_id, date));",
+    // new table storing each line of a note separately
+    "CREATE TABLE IF NOT EXISTS note_lines (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, date TEXT, line_index INTEGER, content TEXT, last_modified INTEGER, UNIQUE(user_id, date, line_index));",
   ]
   for (const cmd of commands) {
     execFileSync('sqlite3', [dbPath, cmd])
@@ -38,22 +41,53 @@ export function createUser(username: string, password: string) {
 
 export function getNote(userId: number, date: string) {
   initDB()
-  const rows = query(`SELECT content, last_modified FROM notes WHERE user_id = ${userId} AND date = '${escape(date)}' LIMIT 1;`)
-  if (rows[0]) {
-    return { content: rows[0].content as string, lastModified: Number(rows[0].last_modified) * 1000 }
+  const rows = query(
+    `SELECT line_index, content, last_modified FROM note_lines WHERE user_id = ${userId} AND date = '${escape(date)}' ORDER BY line_index ASC;`
+  ) as { line_index: number; content: string; last_modified: number }[]
+
+  if (rows.length) {
+    const content = rows.map(r => r.content).join('\n')
+    const lastModified = Math.max(...rows.map(r => Number(r.last_modified))) * 1000
+    return { content, lastModified }
   }
   return undefined
 }
 
 export function upsertNote(userId: number, date: string, content: string) {
   initDB()
-  run(`INSERT INTO notes (user_id, date, content, last_modified) VALUES (${userId}, '${escape(date)}', '${escape(content)}', strftime('%s','now')) ON CONFLICT(user_id, date) DO UPDATE SET content='${escape(content)}', last_modified=strftime('%s','now');`)
+  const lines = content
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l !== '')
+
+  lines.forEach((line, idx) => {
+    run(
+      `INSERT INTO note_lines (user_id, date, line_index, content, last_modified) VALUES (${userId}, '${escape(
+        date
+      )}', ${idx}, '${escape(line)}', strftime('%s','now')) ON CONFLICT(user_id, date, line_index) DO UPDATE SET content='${escape(
+        line
+      )}', last_modified=strftime('%s','now');`
+    )
+  })
+
+  // remove lines that no longer exist
+  run(`DELETE FROM note_lines WHERE user_id = ${userId} AND date = '${escape(date)}' AND line_index >= ${lines.length};`)
 }
 
 export function getAllNotes() {
   initDB()
   const rows = query(
-    `SELECT users.username as username, notes.date as date, notes.content as content FROM notes JOIN users ON notes.user_id = users.id ORDER BY notes.date DESC;`
-  )
-  return rows as { username: string; date: string; content: string }[]
+    `SELECT users.username as username, note_lines.date as date, note_lines.line_index as line_index, note_lines.content as content FROM note_lines JOIN users ON note_lines.user_id = users.id ORDER BY note_lines.date DESC, note_lines.line_index ASC;`
+  ) as { username: string; date: string; line_index: number; content: string }[]
+
+  const grouped: Record<string, { username: string; date: string; content: string }> = {}
+  for (const r of rows) {
+    const key = `${r.username}-${r.date}`
+    if (!grouped[key]) {
+      grouped[key] = { username: r.username, date: r.date, content: r.content }
+    } else {
+      grouped[key].content += `\n${r.content}`
+    }
+  }
+  return Object.values(grouped)
 }


### PR DESCRIPTION
## Summary
- store each journal line as a separate row in `note_lines`
- support retrieving and saving multi-line notes with per-line updates
- update architecture docs for new table

## Testing
- `npm run build` *(fails: Failed to fetch fonts from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_688b2bb9e3dc832f9b460d1a7f136d69