### PR TITLE
Switch notes to per-line storage

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-This project is a Next.js application that allows employees to log order status notes and chat with an AI assistant. The stack uses a SQLite database, server-side API routes, and Google Gemini for LLM capabilities.
+This project is a Next.js application that allows employees to log order status lines and chat with an AI assistant. The stack uses a SQLite database, server-side API routes, and Google Gemini for LLM capabilities.
 
 ## Components
 
@@ -8,8 +8,8 @@ This project is a Next.js application that allows employees to log order status 
 - **SQLite** is used as the persistence layer (`database.sqlite`).
 - Tables:
   - `users` – stores user credentials (`id`, `username`, `password`).
-  - `notes` – stores order notes (`user_id`, `date`, `content`, `last_modified`).
-- Database helpers in `lib/db.ts` provide CRUD operations. A new `getAllNotes` function aggregates every note with its author.
+  - `lines` – each row of a daily log (`user_id`, `date`, `idx`, `content`, `last_modified`).
+  - Database helpers in `lib/db.ts` provide CRUD operations. A new `getAllNotes` function aggregates all lines per user and date.
 
 ### Authentication
 - Sessions are signed tokens stored in a cookie. Creation and verification logic lives in `lib/auth.ts`.
@@ -17,26 +17,26 @@ This project is a Next.js application that allows employees to log order status 
 
 ### API Routes
 - `/api/login`, `/api/register`, `/api/logout` – manage auth.
-- `/api/notes` – fetch or update a user's notes.
-- **`/api/chat`** – new route that collects all notes and sends them to Gemini 2.5 Flash for a single-turn response.
+- `/api/notes` – fetch or update a user's daily lines.
+- **`/api/chat`** – new route that collects all lines and sends them to Gemini 2.5 Flash for a single-turn response.
 
 ### LLM Integration
 1. `app/api/chat/route.ts` initializes `GoogleGenAI` with an API key from `GOOGLE_API_KEY`.
 2. When a POST request with `{ question }` arrives:
    - Session is verified.
-   - All notes are loaded with `getAllNotes()`.
-   - Notes are concatenated and sent to the `gemini-2.5-flash` model along with the user's question.
+   - All lines are loaded with `getAllNotes()`.
+   - Lines are concatenated and sent to the `gemini-2.5-flash` model along with the user's question.
    - The API returns the model's text reply.
 
 ### Client Application
-- `JournalApp.tsx` provides the UI for daily notes and a management chat interface.
+- `JournalApp.tsx` provides the UI for daily status lines and a management chat interface.
 - The management view posts questions to `/api/chat` and displays the response.
-- Daily notes are saved automatically and retrieved via `/api/notes`.
+- Daily lines are saved automatically and retrieved via `/api/notes`.
 
 ## Data Flow
 1. **User Authenticates** – credentials are validated; a session cookie is issued.
-2. **User Enters Notes** – notes are saved to SQLite via `/api/notes`.
-3. **User Queries AI** – a POST to `/api/chat` with the question. The server gathers all notes and queries Gemini.
+2. **User Enters Lines** – lines are saved to SQLite via `/api/notes`.
+3. **User Queries AI** – a POST to `/api/chat` with the question. The server gathers all lines and queries Gemini.
 4. **LLM Response** – the answer is returned and shown in the management chat view.
 
 This architecture keeps the database and AI interaction on the server, while the UI remains a thin Next.js client. To scale, the SQLite database could be replaced with a networked database and the API routes deployed on a serverless or Node environment with access to Google Gemini.


### PR DESCRIPTION
## Summary
- switch DB schema from `notes` table to per-line `lines` table
- update helper functions in `lib/db.ts`
- update architecture overview

## Testing
- `npm run build` *(fails: Failed to fetch font file from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_688b2e363350832f9e331aafb30efab3