### PR TITLE
Trigger SmartTuple refresh from journal

### DIFF
--- a/app/JournalApp.tsx
+++ b/app/JournalApp.tsx
@@ -73,6 +73,22 @@ export default function JournalApp() {
     setCurrentContent(entry?.content || '');
   }, [selectedDate, entries, dateKey]);
 
+  // Trigger smart tuple refresh in the background
+  useEffect(() => {
+    let cancelled = false;
+    async function refresh() {
+      try {
+        await fetch('/api/smarttuple');
+      } catch {}
+    }
+    refresh();
+    const id = setInterval(refresh, 30000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
   useEffect(() => {
     if (currentContent === (entries[dateKey]?.content || '')) return;
 


### PR DESCRIPTION
## Summary
- ping `/api/smarttuple` from JournalApp every 30s

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688c41b1f0a8832fba5cc5d83cfe1330