### PR TITLE
Fix smarttuple prompt with all lines

### DIFF
--- a/app/api/smarttuple/route.ts
+++ b/app/api/smarttuple/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { verifySession } from '@/lib/auth'
 import {
   initDB,
-  getAllNotes,
+  getAllLines,
   getSmartTuples,
   saveSmartTuples,
 } from '@/lib/db'
@@ -20,10 +20,12 @@ export async function GET(request: NextRequest) {
   console.log("function is being run")
 
   console.log("\n Background process called")
-  const notes = getAllNotes()
-  const noteText = notes
-    .map(n => `${n.username} - ${n.date} (last modified ${new Date(n.lastModified).toISOString()}):\n${n.content}`)
-    .join('\n\n')
+  const lines = getAllLines()
+  const noteText = lines
+    .map(
+      l => `${l.username} - ${l.date} [${l.idx}] (last modified ${new Date(l.lastModified).toISOString()}): ${l.content}`
+    )
+    .join('\n')
 
   const prompt =
     `Summarize the status updates for each work order ID from the following log entries. ` +
@@ -53,3 +55,4 @@ export async function GET(request: NextRequest) {
   const tuples = getSmartTuples()
   return NextResponse.json({ tuples })
 }
+

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -118,6 +118,20 @@ export function getAllNotes() {
   }))
 }
 
+export function getAllLines() {
+  initDB()
+  const rows = query(
+    `SELECT users.username as username, lines.date as date, lines.idx as idx, lines.content as content, lines.last_modified as last_modified FROM lines JOIN users ON lines.user_id = users.id ORDER BY lines.date DESC, lines.idx;`
+  ) as { username: string; date: string; idx: number; content: string; last_modified: number }[]
+  return rows.map(r => ({
+    username: r.username,
+    date: r.date,
+    idx: r.idx,
+    content: r.content,
+    lastModified: Number(r.last_modified) * 1000,
+  }))
+}
+
 export function getLatestNoteTimestamp() {
   initDB()
   const rows = query(`SELECT MAX(last_modified) as last FROM lines;`) as { last: number }[]


### PR DESCRIPTION
## Summary
- add `getAllLines` DB helper
- include every line's content and last modified time in `/api/smarttuple` prompt

## Testing
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_688c4d4c4f44832fba6a34428c63f14f