### PR TITLE
feat: keep saved indicator visible

### DIFF
--- a/app/JournalApp.tsx
+++ b/app/JournalApp.tsx
@@ -104,7 +104,6 @@ export default function JournalApp() {
       }).catch(() => {});
       setIsSaving(false);
       setShowSaved(true);
-      setTimeout(() => setShowSaved(false), 2000);
     }, 500);
 
     smartTupleTimeoutRef.current = setTimeout(() => {


### PR DESCRIPTION
## Summary
- keep the "已保存" status message visible after saving by removing the auto-hide timer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688dbe055104832faf0eacc9bc05e3d3