### PR TITLE
feat: add multi-turn management chat

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -18,14 +18,14 @@ This project is a Next.js application that allows employees to log order status 
 ### API Routes
 - `/api/login`, `/api/register`, `/api/logout` – manage auth.
 - `/api/notes` – fetch or update a user's daily lines.
-- **`/api/chat`** – new route that collects all lines and sends them to Gemini 2.5 Flash for a single-turn response.
+- **`/api/chat`** – route that collects all lines and maintains a multi-turn conversation with Gemini 2.5 Flash.
 
 ### LLM Integration
 1. `app/api/chat/route.ts` initializes `GoogleGenAI` with an API key from `GOOGLE_API_KEY`.
-2. When a POST request with `{ question }` arrives to `/api/chat`:
+2. When a POST request with `{ question, history }` arrives to `/api/chat`:
    - Session is verified.
    - All lines are loaded with `getAllNotes()`, which also provides the last modified timestamp for each note.
-   - Lines along with their last modified time are concatenated and sent to the `gemini-2.5-flash` model together with the user's question.
+   - The conversation history is passed to `ai.chats.create`, and the latest question is sent along with the current lines to the `gemini-2.5-flash` model.
    - The API returns the model's text reply.
 
 ### Client Application
@@ -36,7 +36,7 @@ This project is a Next.js application that allows employees to log order status 
 ## Data Flow
 1. **User Authenticates** – credentials are validated; a session cookie is issued.
 2. **User Enters Lines** – lines are saved to SQLite via `/api/notes`.
-3. **User Queries AI** – a POST to `/api/chat` with the question. The server gathers all lines and queries Gemini.
-4. **LLM Response** – the answer is returned and shown in the management chat view.
+3. **User Queries AI** – a POST to `/api/chat` with the question and prior conversation. The server gathers all lines and queries Gemini.
+4. **LLM Response** – the answer is returned and shown in the management chat view, and can be used in follow-up questions.
 
 This architecture keeps the database and AI interaction on the server, while the UI remains a thin Next.js client. To scale, the SQLite database could be replaced with a networked database and the API routes deployed on a serverless or Node environment with access to Google Gemini.


### PR DESCRIPTION
## Summary
- enable AI-powered multi-turn conversation in management interface
- update `/api/chat` to use Gemini chat sessions with history
- document multi-turn chat architecture

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(cannot run: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_688de80a8d58832f9ecad10c3a149495