### PR TITLE
Log lines on management page load

### DIFF
--- a/app/ManagementApp.tsx
+++ b/app/ManagementApp.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { formatDistanceToNow } from "date-fns";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Clock, Building2, User, X } from "lucide-react";
@@ -86,6 +87,7 @@ const kanbanTasks = {
 
 type Task = typeof kanbanTasks["quotation"][0];
 type SelectedTask = Task & { status: string; columnId: string };
+type LineEntry = { content: string; name: string; department: string; lastModified: number };
 
 function TaskModal({ task, onClose }: { task: SelectedTask | null; onClose: () => void }) {
   useEffect(() => {
@@ -200,6 +202,18 @@ function TaskModal({ task, onClose }: { task: SelectedTask | null; onClose: () =
 
 export default function ManagementApp() {
   const [selectedTask, setSelectedTask] = useState<SelectedTask | null>(null);
+
+  useEffect(() => {
+    fetch('/api/lines')
+      .then(res => res.json())
+      .then(data => {
+        (data.lines as LineEntry[]).forEach(line => {
+          const timeAgo = formatDistanceToNow(line.lastModified * 1000, { addSuffix: true });
+          console.log(`${line.content} (edited by ${line.name} in ${line.department}, ${timeAgo})`);
+        });
+      })
+      .catch(err => console.error('Failed to fetch lines', err));
+  }, []);
 
   const getPriorityColor = (priority: string) => {
     switch (priority) {

--- a/app/api/lines/route.ts
+++ b/app/api/lines/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifySession } from '@/lib/auth'
+import { initDB, getLineEntries } from '@/lib/db'
+
+export async function GET(request: NextRequest) {
+  const sessionToken = request.cookies.get('session')?.value
+  const session = verifySession(sessionToken)
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  initDB()
+  const lines = getLineEntries()
+  return NextResponse.json({ lines })
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -127,3 +127,16 @@ export function getAllNotes() {
     lastModified: new Date(Math.max(...v.lastModified) * 1000).toLocaleString('en-US', { timeZone: 'Asia/Shanghai' }),
   }))
 }
+
+export function getLineEntries() {
+  initDB()
+  const rows = query(
+    `SELECT lines.content as content, lines.last_modified as last_modified, users.name as name, users.department as department FROM lines JOIN users ON lines.user_id = users.id ORDER BY lines.date DESC, lines.idx;`
+  ) as { content: string; last_modified: number; name: string; department: string }[]
+  return rows.map(r => ({
+    content: r.content,
+    lastModified: r.last_modified,
+    name: r.name,
+    department: r.department,
+  }))
+}


### PR DESCRIPTION
## Summary
- fetch lines via new `/api/lines` endpoint and log each with user name, department, and relative time
- add database helper `getLineEntries` to retrieve line details from SQLite

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interactive prompt: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68902ff26de0832fa68274fe50e4cd07