### PR TITLE
feat: format lines for LLM prompt

### DIFF
--- a/app/api/kanban/route.ts
+++ b/app/api/kanban/route.ts
@@ -24,18 +24,19 @@ export async function POST(request: NextRequest) {
   if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const rawLines = getLineEntries();
-  const lines = rawLines.map(line => ({
-    content: line.content,
-    name: line.name,
-    department: line.department,
-    timeAgo: formatDistanceToNow(line.lastModified * 1000, { addSuffix: true })
-  }));
+  const linesString = rawLines
+    .map(
+      line =>
+        `Line: ${line.content} last edited ${formatDistanceToNow(line.lastModified * 1000, { addSuffix: true })} by ${line.name} of ${line.department}.`
+    )
+    .join('\n');
 
   const ai = new GoogleGenAI({ apiKey: process.env.GOOGLE_API_KEY });
-  const prompt = `From the following note entries, extract project tasks and organize them into a kanban board. ` +
+  const prompt =
+    `From the following note entries, extract project tasks and organize them into a kanban board. ` +
     `Return a JSON object with keys ${COLUMN_IDS.join(', ')} where each key maps to an array of tasks. ` +
     `Each task should include id, title, priority, dueDate, lastEdited, customerName, representative, and activity (array of {description, timestamp}).\n` +
-    `${JSON.stringify(lines)}`;
+    linesString;
 
   try {
     const response = await ai.models.generateContent({


### PR DESCRIPTION
## Summary
- format note lines as plain text for LLM prompts instead of JSON

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689053dceb94832f8bddf541dfb73ac0