### PR TITLE
fix: fallback for missing Gemini API key

### DIFF
--- a/app/api/kanban/route.ts
+++ b/app/api/kanban/route.ts
@@ -31,7 +31,11 @@ export async function POST(request: NextRequest) {
     )
     .join('\n');
 
-  const ai = new GoogleGenAI({ apiKey: process.env.GOOGLE_API_KEY });
+  const apiKey = process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: 'Missing Google API key' }, { status: 500 });
+  }
+  const ai = new GoogleGenAI({ apiKey });
   const prompt =
     `From the numerous note entries, extract into individual project tasks (ones starting with ynmx-.) and organize them into a kanban board. ` +
     `Return a JSON object with keys ${COLUMN_IDS.join(', ')} where each key maps to an array of tasks. ` +


### PR DESCRIPTION
## Summary
- handle missing Gemini API key in kanban API

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_689057659c48832faccbfc2fac8fd063