### PR TITLE
Persist kanban tasks

### DIFF
--- a/app/ManagementApp.tsx
+++ b/app/ManagementApp.tsx
@@ -160,6 +160,21 @@ export default function ManagementApp() {
   const [kanbanTasks, setKanbanTasks] = useState<Record<string, Task[]>>({});
   const [isRefreshing, setIsRefreshing] = useState(false);
 
+  useEffect(() => {
+    const fetchKanban = async () => {
+      try {
+        const res = await fetch('/api/kanban');
+        if (res.ok) {
+          const data = await res.json();
+          setKanbanTasks(data.tasks ?? {});
+        }
+      } catch (err) {
+        console.error('Failed to fetch kanban', err);
+      }
+    };
+    fetchKanban();
+  }, []);
+
   // Calculate statistics
   const stats = {
     active: 0,

--- a/app/api/kanban/route.ts
+++ b/app/api/kanban/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifySession } from '@/lib/auth';
-import { getLineEntries } from '@/lib/db';
+import { getLineEntries, getKanbanTasks, setKanbanTasks } from '@/lib/db';
 import { GoogleGenAI } from '@google/genai';
 
 const COLUMN_IDS = [
@@ -16,6 +16,15 @@ const COLUMN_IDS = [
   'inspection',
   'shipping',
 ];
+
+export async function GET(request: NextRequest) {
+  const sessionToken = request.cookies.get('session')?.value;
+  const session = verifySession(sessionToken);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const tasks = getKanbanTasks();
+  return NextResponse.json({ tasks });
+}
 
 export async function POST(request: NextRequest) {
   const sessionToken = request.cookies.get('session')?.value;
@@ -145,6 +154,7 @@ export async function POST(request: NextRequest) {
       }
     });
 
+    setKanbanTasks(tasks);
     return NextResponse.json({ tasks });
   } catch (e) {
     console.error("LLM request failed:", e);

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -8,6 +8,7 @@ export function initDB() {
     'ALTER TABLE users ADD COLUMN name TEXT;',
     'ALTER TABLE users ADD COLUMN department TEXT;',
     "CREATE TABLE IF NOT EXISTS lines (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, date TEXT, idx INTEGER, content TEXT, last_modified INTEGER, UNIQUE(user_id, date, idx));",
+    "CREATE TABLE IF NOT EXISTS kanban (id INTEGER PRIMARY KEY CHECK (id = 1), data TEXT);",
   ]
   for (const cmd of commands) {
     try {
@@ -139,4 +140,23 @@ export function getLineEntries() {
     name: r.name,
     department: r.department,
   }))
+}
+
+export function getKanbanTasks() {
+  initDB()
+  const rows = query('SELECT data FROM kanban WHERE id = 1;') as { data?: string }[]
+  if (rows[0]?.data) {
+    try {
+      return JSON.parse(rows[0].data)
+    } catch {
+      return {}
+    }
+  }
+  return {}
+}
+
+export function setKanbanTasks(tasks: Record<string, any[]>) {
+  initDB()
+  const data = escape(JSON.stringify(tasks))
+  run(`INSERT OR REPLACE INTO kanban (id, data) VALUES (1, '${data}');`)
 }


### PR DESCRIPTION
## Summary
- store latest kanban tasks in SQLite and expose a GET API
- retrieve stored tasks on page load so AI output survives refreshes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive ESLint config prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68917e695fbc832f8a2f92186dd2b102